### PR TITLE
Add support for `js.import(path, exportName)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ With `-lib jsImport` you can decorate any extern class with `@:js.import` like s
 - `@:js.import(@star './some/path.js') extern class Foo {}` becomes `import * as Foo from './some/path.js'`
 - `@:js.import(@default './some/path.js') extern class Foo {}` becomes `import Foo from './some/path.js'`
 - `@:js.import('./some/path.js') extern class Foo {}` becomes `import { Foo } from './some/path.js'`
+- - `@:js.import('./some/path.js', 'SomeName') extern class Foo {}` becomes `import { SomeName } from './some/path.js'`

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ With `-lib jsImport` you can decorate any extern class with `@:js.import` like s
 - `@:js.import(@star './some/path.js') extern class Foo {}` becomes `import * as Foo from './some/path.js'`
 - `@:js.import(@default './some/path.js') extern class Foo {}` becomes `import Foo from './some/path.js'`
 - `@:js.import('./some/path.js') extern class Foo {}` becomes `import { Foo } from './some/path.js'`
-- - `@:js.import('./some/path.js', 'SomeName') extern class Foo {}` becomes `import { SomeName } from './some/path.js'`
+- `@:js.import('./some/path.js', 'SomeName') extern class Foo {}` becomes `import { SomeName } from './some/path.js'`

--- a/src/jsImport/Macro.hx
+++ b/src/jsImport/Macro.hx
@@ -37,8 +37,10 @@ class Macro {
                 lines.push('import $id from "$v";');
               case [{ params: [macro $v{(v:String)}] }]:
                 lines.push('import { $id } from "$v";');
+              case [{ params: [macro $v{(v:String)}, macro $v{(exportName:String)}] }]:
+                lines.push('import { $exportName } from "$v";');
               case [{ pos: pos }]:
-                error('@$META requires a string parameter, optionally preceeded by an identifier', pos);
+                error('@$META requires a string parameter, optionally preceded by an identifier', pos);
               default:
                 error('Duplicate @$META', meta[0].pos);
             }

--- a/src/jsImport/Macro.hx
+++ b/src/jsImport/Macro.hx
@@ -30,7 +30,7 @@ class Macro {
             cl.meta.remove(':native');
             cl.meta.add(':native', [macro $v{id}], (macro null).pos);
 
-            var native = switch meta {
+            switch meta {
               case [{ params: [macro @star $v{(v:String)}] }]:
                 lines.push('import * as $id from "$v";');
               case [{ params: [macro @default $v{(v:String)}] }]:

--- a/src/jsImport/Macro.hx
+++ b/src/jsImport/Macro.hx
@@ -30,7 +30,7 @@ class Macro {
             cl.meta.remove(':native');
             cl.meta.add(':native', [macro $v{id}], (macro null).pos);
 
-            switch meta {
+            var native = switch meta {
               case [{ params: [macro @star $v{(v:String)}] }]:
                 lines.push('import * as $id from "$v";');
               case [{ params: [macro @default $v{(v:String)}] }]:
@@ -38,7 +38,7 @@ class Macro {
               case [{ params: [macro $v{(v:String)}] }]:
                 lines.push('import { $id } from "$v";');
               case [{ params: [macro $v{(v:String)}, macro $v{(exportName:String)}] }]:
-                lines.push('import { $exportName } from "$v";');
+                lines.push('import { $exportName as $id } from "$v";');
               case [{ pos: pos }]:
                 error('@$META requires a string parameter, optionally preceded by an identifier', pos);
               default:


### PR DESCRIPTION
For example:

```haxe
@:js.import("three/examples/jsm/controls/OrbitControls.js") extern class OrbitControls {
```

does not work because it tries to import "three_examples_jsm_controls_orbitcontrols_OrbitControls", rather than just OrbitControls. Given the module could export under any name, we need a variant where we specify which import we want